### PR TITLE
awp support for message filtering

### DIFF
--- a/docs/docs/SUMMARY.md
+++ b/docs/docs/SUMMARY.md
@@ -53,6 +53,7 @@ search:
                         - [WorkflowInfo](api/fastagency/adapters/awp/base/WorkflowInfo.md)
                     - tryrun
                         - [simple_workflow](api/fastagency/adapters/awp/tryrun/simple_workflow.md)
+                        - [without_student_messages](api/fastagency/adapters/awp/tryrun/without_student_messages.md)
                 - fastapi
                     - [FastAPIAdapter](api/fastagency/adapters/fastapi/FastAPIAdapter.md)
                     - [FastAPIProvider](api/fastagency/adapters/fastapi/FastAPIProvider.md)

--- a/docs/docs/en/api/fastagency/adapters/awp/tryrun/without_student_messages.md
+++ b/docs/docs/en/api/fastagency/adapters/awp/tryrun/without_student_messages.md
@@ -1,0 +1,11 @@
+---
+# 0.5 - API
+# 2 - Release
+# 3 - Contributing
+# 5 - Template Page
+# 10 - Default
+search:
+  boost: 0.5
+---
+
+::: fastagency.adapters.awp.tryrun.without_student_messages

--- a/fastagency/adapters/awp/tryrun.py
+++ b/fastagency/adapters/awp/tryrun.py
@@ -47,7 +47,13 @@ def simple_workflow(ui: UI, params: dict[str, Any]) -> str:
     return ui.process(response)  # type: ignore[no-any-return]
 
 
-adapter = AWPAdapter(provider=wf, wf_name="simple_learning")
+def without_student_messages(message: Any) -> bool:
+    return not (message.type == "text" and message.content.sender == "Student_Agent")
+
+
+adapter = AWPAdapter(
+    provider=wf, wf_name="simple_learning", filter=without_student_messages
+)
 
 app = FastAPI()
 app.include_router(adapter.router)


### PR DESCRIPTION
# Description

AWPAdapter constructor now receives optional callable, which can be used to filter out messages that are forwarded to AWP

example:
 
```
def without_student_messages(message: Any) -> bool:
    return not (message.type == "text" and message.content.sender == "Student_Agent")


adapter = AWPAdapter(
    provider=wf, wf_name="simple_learning", filter=without_student_messages
)
```

messages that need to return result (like input messages should not be filtered)


## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Documentation (typos, code examples, or any documentation updates)
- [ ] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] I have included code examples to illustrate the modifications
